### PR TITLE
fix: correctly call sdk.actions.ready() to hide miniapp splash image

### DIFF
--- a/docs/public/.well-known/farcaster.json
+++ b/docs/public/.well-known/farcaster.json
@@ -4,7 +4,7 @@
 		"payload": "eyJkb21haW4iOiJkb2NzLmdldGphY2sub3JnIn0",
 		"signature": "NTriUPOX/Z8B6qdc7EMjV3+vEs4f2ULdbW42kkT+K0lpwavaEHBlyf5/8H3OUIuUL5SwzN9jMuiccDRsoe0QgBw="
 	},
-	"miniapp": {
+	"frame": {
 		"version": "1",
 		"name": "jack",
 		"iconUrl": "https://docs.getjack.org/icon.png",

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -88,11 +88,7 @@ export default defineConfig({
 						`<meta name="fc:miniapp" content='${miniappMeta}' />
 <script type="module">
   import('https://esm.sh/@farcaster/miniapp-sdk@0.2.1').then(({ sdk }) => {
-    if (document.readyState === 'complete') {
-      sdk.actions.ready();
-    } else {
-      window.addEventListener('load', () => sdk.actions.ready());
-    }
+    sdk.actions.ready();
   }).catch(() => {});
 </script>
 </head>`,


### PR DESCRIPTION
- Change farcaster.json manifest key from 'miniapp' to 'frame' per
  Farcaster spec
- Simplify SDK initialization by calling ready() immediately when
  import resolves, fixing race condition where load event could fire
  before the listener was attached