### PR TITLE
fix: skip version cache for explicit jack update command

### DIFF
--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -33,9 +33,9 @@ export default async function update(): Promise<void> {
 
 	info(`Current version: v${currentVersion}`);
 
-	// Check for updates
+	// Check for updates - skip cache since user explicitly requested update
 	debug("Fetching latest version from npm...");
-	const latestVersion = await checkForUpdate();
+	const latestVersion = await checkForUpdate(true);
 	debug(`Latest version from npm: ${latestVersion ?? "none (you're up to date)"}`);
 
 	if (!latestVersion) {

--- a/apps/cli/src/lib/version-check.ts
+++ b/apps/cli/src/lib/version-check.ts
@@ -85,20 +85,25 @@ function isNewerVersion(latest: string, current: string): boolean {
 /**
  * Check if an update is available (uses cache, non-blocking)
  * Returns the latest version if newer, null otherwise
+ * @param skipCache - If true, bypass the cache and always fetch from npm
  */
-export async function checkForUpdate(): Promise<string | null> {
+export async function checkForUpdate(
+	skipCache = false,
+): Promise<string | null> {
 	const currentVersion = getCurrentVersion();
 
-	// Check cache first
-	const cache = await readVersionCache();
-	const now = Date.now();
+	// Check cache first (unless skipCache is true)
+	if (!skipCache) {
+		const cache = await readVersionCache();
+		const now = Date.now();
 
-	if (cache && now - cache.checkedAt < CACHE_TTL_MS) {
-		// Use cached value
-		if (isNewerVersion(cache.latestVersion, currentVersion)) {
-			return cache.latestVersion;
+		if (cache && now - cache.checkedAt < CACHE_TTL_MS) {
+			// Use cached value
+			if (isNewerVersion(cache.latestVersion, currentVersion)) {
+				return cache.latestVersion;
+			}
+			return null;
 		}
-		return null;
 	}
 
 	// Fetch fresh version (don't await in caller for non-blocking)


### PR DESCRIPTION
The update command was using a 24-hour cache for version checks, which
caused stale data when a new version was published. Users would see
"You're on the latest version!" even when updates were available.

Now `jack update` always fetches fresh from npm, while background
startup checks still use the cache for performance.